### PR TITLE
#17 - texture enum class 네이밍 수정

### DIFF
--- a/SR_Project/Client/Code/Loader.cpp
+++ b/SR_Project/Client/Code/Loader.cpp
@@ -86,7 +86,7 @@ HRESULT Loader::Load_TestScene()
 
 	/*--------------Load File Resource-----------------*/
 	resource->LoadTerrain(L"../Resource/Texture/Terrain/Height1.bmp", L"Basic_Terrain", 50.f, 1.f);
-	resource->LoadTexture(L"../Resource/Texture/Terrain/Terrain0.png",L"Basic_Terrain_Texture", TEXTURE::Tex_Normal);
+	resource->LoadTexture(L"../Resource/Texture/Terrain/Terrain0.png",L"Basic_Terrain_Texture", TEXTURE::Tex_Diffuse);
 	auto terrainMtrl = Material::Create();
 	terrainMtrl->SetTexture(L"Basic_Terrain_Texture");
 	resource->LoadMaterial(L"Terrain_Mtrl", terrainMtrl);

--- a/SR_Project/Engine/Code/ResourceManager.cpp
+++ b/SR_Project/Engine/Code/ResourceManager.cpp
@@ -50,7 +50,7 @@ void ResourceManager::LoadTexture(const std::wstring& filePath, const std::wstri
 
     switch (texType)
     {
-    case Engine::TEXTURE::Tex_Normal:
+    case Engine::TEXTURE::Tex_Diffuse:
         D3DXCreateTextureFromFileW(device, filePath.c_str(), (LPDIRECT3DTEXTURE9*)&tex);
         break;
     case Engine::TEXTURE::Tex_Cube:

--- a/SR_Project/Engine/Header/Engine_Enum.h
+++ b/SR_Project/Engine/Header/Engine_Enum.h
@@ -10,7 +10,7 @@ namespace Engine
 	enum class INFO { Info_Right, Info_Up, Info_Look, Info_Pos, Info_End };
 	enum class ROTATION { Rot_X, Rot_Y, Rot_Z, Rot_End };
 
-	enum class TEXTURE { Tex_Normal, Tex_Cube, Tex_Sprite ,Tex_End };
+	enum class TEXTURE { Tex_Diffuse, Tex_Cube, Tex_Normal ,Tex_End };
 
 	enum class RENDER_ID { Render_Priority, Render_NonAlpha, Render_Mask, Render_Shadow, Render_Reflect, Render_Alpha, Render_UI, Render_End };
 

--- a/SR_Project/Reference/Header/Engine_Enum.h
+++ b/SR_Project/Reference/Header/Engine_Enum.h
@@ -10,7 +10,7 @@ namespace Engine
 	enum class INFO { Info_Right, Info_Up, Info_Look, Info_Pos, Info_End };
 	enum class ROTATION { Rot_X, Rot_Y, Rot_Z, Rot_End };
 
-	enum class TEXTURE { Tex_Normal, Tex_Cube, Tex_Sprite ,Tex_End };
+	enum class TEXTURE { Tex_Diffuse, Tex_Cube, Tex_Normal ,Tex_End };
 
 	enum class RENDER_ID { Render_Priority, Render_NonAlpha, Render_Mask, Render_Shadow, Render_Reflect, Render_Alpha, Render_UI, Render_End };
 


### PR DESCRIPTION
tex_normal -> tex_diffuse
tex_normal은 진짜 노멀맵 사용시에 사용

## #️⃣ Issue Number

#17 

## 📝 요약(Summary)

texture enum class 네이밍 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
